### PR TITLE
Make `rootUri` optional and repsond to all request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,15 @@ class LanguageServerPlugin implements PluginValue {
         this.initialize({
             documentText: this.view.state.doc.toString(),
         });
+        this.transport.connection.addEventListener(
+            'message',
+            (message: any) => {
+                const data = JSON.parse(message.data);
+                if (data.method && data.id) {
+                    this.processRequest(data);
+                }
+            }
+        );
     }
 
     update({ docChanged }: ViewUpdate) {
@@ -353,6 +362,15 @@ class LanguageServerPlugin implements PluginValue {
         } catch (error) {
             console.error(error);
         }
+    }
+
+    processRequest({ id }: any) {
+        // Respond to all requests with an empty result, as every processed
+        // request must send a response back to the sender of the request.
+        // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage
+        this.transport.connection.send(
+            JSON.stringify({ jsonrpc: '2.0', id, result: null })
+        );
     }
 
     processDiagnostics(params: PublishDiagnosticsParams) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const CompletionItemKindMap = Object.fromEntries(
 const useLast = (values: readonly string[]) => values.reduce((_, v) => v, '');
 
 const serverUri = Facet.define<string, string>({ combine: useLast });
-const rootUri = Facet.define<string, string>({ combine: useLast });
+const rootUri = Facet.define<string, string | undefined>({ combine: useLast });
 const documentUri = Facet.define<string, string>({ combine: useLast });
 const languageId = Facet.define<string, string>({ combine: useLast });
 
@@ -190,7 +190,7 @@ class LanguageServerPlugin implements PluginValue {
             initializationOptions: null,
             processId: null,
             rootUri: this.rootUri,
-            workspaceFolders: [
+            workspaceFolders: this.rootUri && [
                 {
                     name: 'root',
                     uri: this.rootUri,
@@ -385,7 +385,7 @@ class LanguageServerPlugin implements PluginValue {
 
 interface LanguageServerOptions {
     serverUri: `ws://${string}` | `wss://${string}`;
-    rootUri: string;
+    rootUri?: string;
     documentUri: string;
     languageId: string;
 }


### PR DESCRIPTION
Closes #9 

I had problems using this plugin together with sumneko's [lua-language-server](https://github.com/sumneko/lua-language-server/). It worked when omitting the `rootUri` (see https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder%3F) and sending a response to every rpc server request (see the specifications: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage).

I'm not sure if the way I implemented it is the most straight forward way and I was a bit lost with alle the types, therefore used `any`. So feel free to change the PR to your liking.