### PR TITLE
feat: Transport agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,18 @@ npm i codemirror-languageserver
 ```
 
 ``` js
-import { WebSocketTransport } from "@open-rpc/client-js";
 import { languageServer } from 'codemirror-languageserver';
 
-// WebSocket transport
 const transport = new WebSocketTransport(serverUri)
 
 var ls = languageServer({
-	// Transport and other client options.
-	transport,
+	// WebSocket server uri and other client options.
+	serverUri,
 	rootUri: 'file:///',
 
 	// Alternatively, to share the same client across multiple instances of this plugin.
 	client: new LanguageServerClient({
-		transport,
+		serverUri,
 		rootUri: 'file:///'
 	}),
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ npm i codemirror-languageserver
 ```
 
 ``` js
+import { WebSocketTransport } from "@open-rpc/client-js";
 import { languageServer } from 'codemirror-languageserver';
 
+// WebSocket transport
+const transport = new WebSocketTransport(serverUri)
+
 var ls = languageServer({
-	// WebSocket server URI and other client options.
-	serverUri: serverUri,
+	// Transport and other client options.
+	transport,
 	rootUri: 'file:///',
 
 	// Alternatively, to share the same client across multiple instances of this plugin.
 	client: new LanguageServerClient({
-		serverUri: serverUri,
+		transport,
 		rootUri: 'file:///'
 	}),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.8",
-        "@codemirror/lint": "^0.19.3",
-        "@codemirror/state": "^0.19.8",
-        "@codemirror/tooltip": "^0.19.14",
-        "@codemirror/view": "^0.19.43",
+        "@codemirror/autocomplete": "^0.20.0",
+        "@codemirror/lint": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/tooltip": "^0.19.16",
+        "@codemirror/view": "^0.20.0",
         "@open-rpc/client-js": "^1.7.1",
         "vscode-languageserver-protocol": "^3.16.0"
       },
@@ -1167,72 +1167,47 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
-      "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.0.tgz",
+      "integrity": "sha512-F6VOM8lImn5ApqxJcaWgdl7hhlw8B5yAfZJGlsQifcpNotkZOMND61mBFZ84OmSLWxtT8/smkSeLvJupKbjP9w==",
       "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/gutter": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
-      "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
-      "dependencies": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0"
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
+      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
       "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0",
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0"
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
-      "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.2.tgz",
+      "integrity": "sha512-xEH3wlzoFLEhPEeMVRNoQIhoTCMEtXhVxemGh3FYjLfl/CL3B2Wz+CU7ooP5SKhN1le7JqUNSfiTArFP+IzFuw==",
       "dependencies": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.5",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.2",
         "crelt": "^1.0.5"
       }
     },
-    "node_modules/@codemirror/panel": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
-      "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
     "node_modules/@codemirror/rangeset": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
-      "integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
+      "integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
       "dependencies": {
         "@codemirror/state": "^0.19.0"
       }
     },
-    "node_modules/@codemirror/state": {
+    "node_modules/@codemirror/rangeset/node_modules/@codemirror/state": {
       "version": "0.19.9",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
       "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
@@ -1240,24 +1215,37 @@
         "@codemirror/text": "^0.19.0"
       }
     },
+    "node_modules/@codemirror/state": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
+      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
+    },
     "node_modules/@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "node_modules/@codemirror/tooltip": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.15.tgz",
-      "integrity": "sha512-Fb4fKgVziUNSOAhclsvsqHw+1bCfh5po8xT/hw2UQW0UV41t73tJqX5AiqSwmtaDHExN7DFyzG8VQa05d/7g3Q==",
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
       "dependencies": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
-    "node_modules/@codemirror/view": {
-      "version": "0.19.44",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.44.tgz",
-      "integrity": "sha512-vahNUE6hSXdjzs1gcztKPJQhZu+ZIwRpK4ZGZTSD81/CZUVqtlF75W3RCYVgEdjTI1l6ogJmIL6FM2Xj7ltn7Q==",
+    "node_modules/@codemirror/tooltip/node_modules/@codemirror/state": {
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+      "dependencies": {
+        "@codemirror/text": "^0.19.0"
+      }
+    },
+    "node_modules/@codemirror/tooltip/node_modules/@codemirror/view": {
+      "version": "0.19.48",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
       "dependencies": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -1266,17 +1254,35 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@codemirror/view": {
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.4.tgz",
+      "integrity": "sha512-6yprcc0/39EzI6y9Jm/J5F9lFzQik0yj8gE3CO/wOCQ4vd3Drol114mMK91LGtKrfoS0MFKVGulw0TdfN49Bfw==",
+      "dependencies": {
+        "@codemirror/state": "^0.20.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@lezer/common": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
-      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
+      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
+      "dependencies": {
+        "@lezer/common": "^0.16.0"
+      }
     },
     "node_modules/@lezer/lr": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
-      "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
+      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
       "dependencies": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^0.16.0"
       }
     },
     "node_modules/@mdn/browser-compat-data": {
@@ -3423,116 +3429,126 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.8.tgz",
-      "integrity": "sha512-o4I1pRlFjhBHOYab+QfpKcW0B8FqAH+2pdmCYrkTz3bm1djVwhlMEhv1s/aTKhdjLtkfZFUbdHBi+8xe22wUCA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.20.0.tgz",
+      "integrity": "sha512-F6VOM8lImn5ApqxJcaWgdl7hhlw8B5yAfZJGlsQifcpNotkZOMND61mBFZ84OmSLWxtT8/smkSeLvJupKbjP9w==",
       "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/gutter": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.5.tgz",
-      "integrity": "sha512-Vqy+RXgBdnmbxNYx4/irQcfU9ecFz8SB/vhDOeHHSGtDqs+TihYHnHgBZLz6uILEG0YIjp0/zYY3P2NgZ/iyEg==",
-      "requires": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^0.20.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0"
       }
     },
     "@codemirror/language": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.5.tgz",
-      "integrity": "sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.0.tgz",
+      "integrity": "sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.0",
+        "@lezer/common": "^0.16.0",
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0"
       }
     },
     "@codemirror/lint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
-      "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.20.2.tgz",
+      "integrity": "sha512-xEH3wlzoFLEhPEeMVRNoQIhoTCMEtXhVxemGh3FYjLfl/CL3B2Wz+CU7ooP5SKhN1le7JqUNSfiTArFP+IzFuw==",
       "requires": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.5",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/state": "^0.20.0",
+        "@codemirror/view": "^0.20.2",
         "crelt": "^1.0.5"
       }
     },
-    "@codemirror/panel": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.0.tgz",
-      "integrity": "sha512-LJuu49xnuhaAztlhnLJQ57ddOirSyf8/lnl7twsQUG/05RkxodBZ9F7q8r5AOLqOkaQOy9WySEKX1Ur8lD9Q5w==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
     "@codemirror/rangeset": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
-      "integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
+      "integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
       "requires": {
         "@codemirror/state": "^0.19.0"
+      },
+      "dependencies": {
+        "@codemirror/state": {
+          "version": "0.19.9",
+          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+          "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+          "requires": {
+            "@codemirror/text": "^0.19.0"
+          }
+        }
       }
     },
     "@codemirror/state": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
-      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
-      "requires": {
-        "@codemirror/text": "^0.19.0"
-      }
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.0.tgz",
+      "integrity": "sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A=="
     },
     "@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.15.tgz",
-      "integrity": "sha512-Fb4fKgVziUNSOAhclsvsqHw+1bCfh5po8xT/hw2UQW0UV41t73tJqX5AiqSwmtaDHExN7DFyzG8VQa05d/7g3Q==",
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
+      },
+      "dependencies": {
+        "@codemirror/state": {
+          "version": "0.19.9",
+          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+          "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+          "requires": {
+            "@codemirror/text": "^0.19.0"
+          }
+        },
+        "@codemirror/view": {
+          "version": "0.19.48",
+          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+          "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+          "requires": {
+            "@codemirror/rangeset": "^0.19.5",
+            "@codemirror/state": "^0.19.3",
+            "@codemirror/text": "^0.19.0",
+            "style-mod": "^4.0.0",
+            "w3c-keyname": "^2.2.4"
+          }
+        }
       }
     },
     "@codemirror/view": {
-      "version": "0.19.44",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.44.tgz",
-      "integrity": "sha512-vahNUE6hSXdjzs1gcztKPJQhZu+ZIwRpK4ZGZTSD81/CZUVqtlF75W3RCYVgEdjTI1l6ogJmIL6FM2Xj7ltn7Q==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.4.tgz",
+      "integrity": "sha512-6yprcc0/39EzI6y9Jm/J5F9lFzQik0yj8gE3CO/wOCQ4vd3Drol114mMK91LGtKrfoS0MFKVGulw0TdfN49Bfw==",
       "requires": {
-        "@codemirror/rangeset": "^0.19.5",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
+        "@codemirror/state": "^0.20.0",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
     },
     "@lezer/common": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.8.tgz",
-      "integrity": "sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
+    },
+    "@lezer/highlight": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
+      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
+      "requires": {
+        "@lezer/common": "^0.16.0"
+      }
     },
     "@lezer/lr": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.4.tgz",
-      "integrity": "sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.2.tgz",
+      "integrity": "sha512-bx7kkp4eLOzp+YclKMOx1P0OzWRH/6Y3EdEvsHC+rhsc7H72GvccwlKfuXlWkiKjnmzlxLTFxsNjA8v+Yj75mQ==",
       "requires": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^0.16.0"
       }
     },
     "@mdn/browser-compat-data": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@codemirror/autocomplete": "^0.19.8",
-    "@codemirror/lint": "^0.19.3",
-    "@codemirror/state": "^0.19.8",
-    "@codemirror/tooltip": "^0.19.14",
-    "@codemirror/view": "^0.19.43",
+    "@codemirror/autocomplete": "^0.20.0",
+    "@codemirror/lint": "^0.20.0",
+    "@codemirror/state": "^0.20.0",
+    "@codemirror/view": "^0.20.0",
     "@open-rpc/client-js": "^1.7.1",
     "vscode-languageserver-protocol": "^3.16.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,14 +214,6 @@ export class LanguageServerClient {
         return this.client.notify({ method, params });
     }
 
-    private processRequest({ id }: { id: string }) {
-        this.transport.sendData({
-            jsonrpc: '2.0',
-            id,
-            result: null
-        } as any);
-    }
-
     private processNotification(notification: Notification) {
         for (const plugin of this.plugins)
             plugin.processNotification(notification);


### PR DESCRIPTION
Reference: https://github.com/FurqanSoftware/codemirror-languageserver/issues/12

It now accepts any object implementing `Transport`.

I removed `processRequest` method which wasn't needed btw.

The example now would look something like:

```ts
import { WebSocketTransport } from "@open-rpc/client-js";
import { languageServer } from 'codemirror-languageserver';

// WebSocket transport
const transport = new WebSocketTransport(serverUri)

var ls = languageServer({
	// Transport and other client options.
	transport,
	rootUri: 'file:///',

	// Alternatively, to share the same client across multiple instances of this plugin.
	client: new LanguageServerClient({
		transport,
		rootUri: 'file:///'
	}),

	documentUri: `file:///${filename}`,
	languageId: 'cpp' // As defined at https://microsoft.github.io/language-server-protocol/specification#textDocumentItem.
});

var view = new EditorView({
	state: EditorState.create({
		extensions: [
			// ...
			ls,
			// ...
		]
	})
});
```

I have tried it with Event Emitter and WebSockets transports and both work fine! :-)

![image](https://user-images.githubusercontent.com/38158676/167679040-aa89251b-5a6a-4f07-ab8b-37de9c77b675.png)

Awesome job you have done with this library
