### PR TITLE
initializationOptions with TypeScript generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,47 @@ This plugin enables code completion, hover tooltips, and linter functionality by
 npm i codemirror-languageserver
 ```
 
-``` js
+```js
 import { languageServer } from 'codemirror-languageserver';
 
-const transport = new WebSocketTransport(serverUri)
+const transport = new WebSocketTransport(serverUri);
 
 var ls = languageServer({
-	// WebSocket server uri and other client options.
-	serverUri,
-	rootUri: 'file:///',
+    // WebSocket server uri and other client options.
+    serverUri,
+    rootUri: 'file:///',
 
-	// Alternatively, to share the same client across multiple instances of this plugin.
-	client: new LanguageServerClient({
-		serverUri,
-		rootUri: 'file:///'
-	}),
+    // Alternatively, to share the same client across multiple instances of this plugin.
+    client: new LanguageServerClient({
+        serverUri,
+        rootUri: 'file:///',
+    }),
 
-	documentUri: `file:///${filename}`,
-	languageId: 'cpp' // As defined at https://microsoft.github.io/language-server-protocol/specification#textDocumentItem.
+    documentUri: `file:///${filename}`,
+    languageId: 'cpp', // As defined at https://microsoft.github.io/language-server-protocol/specification#textDocumentItem.
 });
 
 var view = new EditorView({
-	state: EditorState.create({
-		extensions: [
-			// ...
-			ls,
-			// ...
-		]
-	})
+    state: EditorState.create({
+        extensions: [
+            // ...
+            ls,
+            // ...
+        ],
+    }),
 });
 ```
+
+### Using with Initialization Options
+
+The plugin includes built-in TypeScript definitions for popular language servers:
+
+-   `PyrightInitializationOptions` - Python (Pyright)
+-   `RustAnalyzerInitializationOptions` - Rust (rust-analyzer)
+-   `TypeScriptInitializationOptions` - TypeScript/JavaScript
+-   `ESLintInitializationOptions` - ESLint
+-   `ClangdInitializationOptions` - C/C++ (Clangd)
+-   `GoplsInitializationOptions` - Go (Gopls)
 
 ## Contributing
 
@@ -51,7 +62,7 @@ Contributions are welcome.
 
 https://user-images.githubusercontent.com/348107/120141150-c6bb9180-c1fd-11eb-8ada-9b7b7a1e4ade.mp4
 
-- [Toph](https://toph.co): Competitive programming platform. Toph uses Language Server Plugin for CodeMirror 6 with its integrated code editor.
+-   [Toph](https://toph.co): Competitive programming platform. Toph uses Language Server Plugin for CodeMirror 6 with its integrated code editor.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,14 +71,13 @@ type Notification = {
     };
 }[keyof LSPEventMap];
 
-export class LanguageServerClient {
-
+export class LanguageServerClient<TInitOptions = unknown> {
     public ready: boolean;
     public capabilities: LSP.ServerCapabilities<any>;
 
     public initializePromise: Promise<void>;
-    private rootUri: string;
-    private workspaceFolders: LSP.WorkspaceFolder[];
+    private rootUri: string | null;
+    private workspaceFolders: LSP.WorkspaceFolder[] | null;
     private autoClose?: boolean;
 
     private transport: Transport;
@@ -86,8 +85,10 @@ export class LanguageServerClient {
     private client: Client;
 
     private plugins: LanguageServerPlugin[];
+    private options: LanguageServerClientOptions<TInitOptions>;
 
-    constructor(options: LanguageServerClientOptions) {
+    constructor(options: LanguageServerClientOptions<TInitOptions>) {
+        this.options = options;
         this.rootUri = options.rootUri;
         this.workspaceFolders = options.workspaceFolders;
         this.autoClose = options.autoClose;
@@ -120,8 +121,8 @@ export class LanguageServerClient {
         this.initializePromise = this.initialize();
     }
 
-    public async initialize() {
-        const { capabilities } = await this.request("initialize", {
+    protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
+        return {
             capabilities: {
                 textDocument: {
                     hover: {
@@ -175,11 +176,19 @@ export class LanguageServerClient {
                     },
                 },
             },
-            initializationOptions: null,
+            initializationOptions: this.options.initializationOptions ?? null,
             processId: null,
             rootUri: this.rootUri,
             workspaceFolders: this.workspaceFolders,
-        }, timeout * 3);
+        }
+    }
+
+    public async initialize() {
+        const { capabilities } = await this.request(
+            "initialize",
+            this.getInitializationOptions(),
+            timeout * 3,
+        );
         this.capabilities = capabilities;
         this.notify("initialized", {});
         this.ready = true;
@@ -216,7 +225,7 @@ export class LanguageServerClient {
         if (this.autoClose) { this.close(); }
     }
 
-    private request<K extends keyof LSPRequestMap>(
+    protected request<K extends keyof LSPRequestMap>(
         method: K,
         params: LSPRequestMap[K][0],
         timeout: number,
@@ -224,14 +233,14 @@ export class LanguageServerClient {
         return this.client.request({ method, params }, timeout);
     }
 
-    private notify<K extends keyof LSPNotifyMap>(
+    protected notify<K extends keyof LSPNotifyMap>(
         method: K,
         params: LSPNotifyMap[K],
     ): Promise<LSPNotifyMap[K]> {
         return this.client.notify({ method, params });
     }
 
-    private processNotification(notification: Notification) {
+    protected processNotification(notification: Notification) {
         for (const plugin of this.plugins) {
             plugin.processNotification(notification);
         }
@@ -512,34 +521,36 @@ interface LanguageServerBaseOptions {
     languageId: string;
 }
 
-interface LanguageServerClientOptions extends LanguageServerBaseOptions {
+interface LanguageServerClientOptions<TInitOptions = unknown> extends LanguageServerBaseOptions {
     transport: Transport;
     autoClose?: boolean;
+    initializationOptions?: TInitOptions;
 }
 
-interface LanguageServerOptions extends LanguageServerClientOptions {
-    client?: LanguageServerClient;
+interface LanguageServerOptions<TInitOptions = unknown> extends LanguageServerClientOptions<TInitOptions> {
+    client?: LanguageServerClient<TInitOptions>;
     allowHTMLContent?: boolean;
 }
 
-interface LanguageServerWebsocketOptions extends LanguageServerBaseOptions {
+interface LanguageServerWebsocketOptions<TInitOptions = unknown> extends LanguageServerBaseOptions {
     serverUri: `ws://${string}` | `wss://${string}`;
+    initializationOptions?: TInitOptions;
 }
 
-export function languageServer(options: LanguageServerWebsocketOptions) {
+export function languageServer<TInitOptions = unknown>(options: LanguageServerWebsocketOptions<TInitOptions>) {
     const serverUri = options.serverUri;
-    delete options.serverUri;
-    return languageServerWithTransport({
-        ...options,
+    const { serverUri: _, ...optionsWithoutServerUri } = options;
+    return languageServerWithTransport<TInitOptions>({
+        ...optionsWithoutServerUri,
         transport: new WebSocketTransport(serverUri),
     });
 }
 
-export function languageServerWithTransport(options: LanguageServerOptions) {
+export function languageServerWithTransport<TInitOptions = unknown>(options: LanguageServerOptions<TInitOptions>) {
     let plugin: LanguageServerPlugin | null = null;
 
     return [
-        client.of(options.client || new LanguageServerClient({...options, autoClose: true})),
+        client.of(options.client || new LanguageServerClient<TInitOptions>({...options, autoClose: true})),
         documentUri.of(options.documentUri),
         languageId.of(options.languageId),
         ViewPlugin.define((view) => (plugin = new LanguageServerPlugin(view, options.allowHTMLContent))),
@@ -636,10 +647,11 @@ function prefixMatch(items: LSP.CompletionItem[]) {
     const rest = new Set<string>();
 
     for (const item of items) {
-        const [initial, ...restStr] = item.textEdit?.newText || item.label;
+        const text = item.textEdit?.newText || item.label;
+        const initial = text[0];
         first.add(initial);
-        for (const char of restStr) {
-            rest.add(char);
+        for (let i = 1; i < text.length; i++) {
+            rest.add(text[i]);
         }
     }
 
@@ -655,4 +667,291 @@ function isLSPMarkupContent(
     contents: LSP.MarkupContent | LSP.MarkedString | LSP.MarkedString[],
 ): contents is LSP.MarkupContent {
     return (contents as LSP.MarkupContent).kind !== undefined;
+}
+
+// Ready-to-use types for popular LSP servers
+
+/**
+ * Initialization options for Pyright language server
+ * @see https://github.com/microsoft/pyright/blob/main/docs/settings.md
+ */
+export interface PyrightInitializationOptions {
+    python?: {
+        pythonPath?: string;
+        venvPath?: string;
+        analysis?: {
+            autoSearchPaths?: boolean;
+            extraPaths?: string[];
+            diagnosticMode?: "workspace" | "openFilesOnly";
+            stubPath?: string;
+            typeshedPaths?: string[];
+            useLibraryCodeForTypes?: boolean;
+            typeCheckingMode?: "off" | "basic" | "strict";
+            autoImportCompletions?: boolean;
+            indexing?: boolean;
+        };
+    };
+    reportMissingImports?: boolean;
+    reportMissingTypeStubs?: boolean;
+    reportMissingModuleSource?: boolean;
+    reportInvalidTypeVarUse?: boolean;
+    reportOptionalSubscript?: boolean;
+    reportOptionalMemberAccess?: boolean;
+    reportOptionalCall?: boolean;
+    reportOptionalIterable?: boolean;
+    reportOptionalContextManager?: boolean;
+    reportOptionalOperand?: boolean;
+    reportTypedDictNotRequiredAccess?: boolean;
+    reportPrivateImportUsage?: boolean;
+    reportConstantRedefinition?: boolean;
+    reportIncompatibleMethodOverride?: boolean;
+    reportIncompatibleVariableOverride?: boolean;
+    reportInconsistentConstructor?: boolean;
+}
+
+/**
+ * Initialization options for Rust Analyzer language server
+ * @see https://rust-analyzer.github.io/manual.html#configuration
+ */
+export interface RustAnalyzerInitializationOptions {
+    cargo?: {
+        buildScripts?: {
+            enable?: boolean;
+            invocationStrategy?: "per_workspace" | "once";
+            invocationLocation?: "workspace" | "root";
+        };
+        allTargets?: boolean;
+        noDefaultFeatures?: boolean;
+        allFeatures?: boolean;
+        features?: string[];
+        target?: string;
+        runBuildScripts?: boolean;
+        useRustcWrapperForBuildScripts?: boolean;
+    };
+    procMacro?: {
+        enable?: boolean;
+        ignored?: Record<string, string[]>;
+        server?: string;
+        attributes?: {
+            enable?: boolean;
+        };
+    };
+    diagnostics?: {
+        enable?: boolean;
+        disabled?: string[];
+        warningsAsHint?: string[];
+        warningsAsInfo?: string[];
+        remapPrefix?: Record<string, string>;
+        experimental?: {
+            enable?: boolean;
+        };
+    };
+    completion?: {
+        addCallArgumentSnippets?: boolean;
+        addCallParenthesis?: boolean;
+        postfix?: {
+            enable?: boolean;
+        };
+        autoimport?: {
+            enable?: boolean;
+        };
+        privateEditable?: {
+            enable?: boolean;
+        };
+    };
+    assist?: {
+        importGranularity?: "preserve" | "crate" | "module" | "item";
+        importEnforceGranularity?: boolean;
+        importPrefix?: "plain" | "by_self" | "by_crate";
+        allowMergingIntoGlobImports?: boolean;
+    };
+    callInfo?: {
+        full?: boolean;
+    };
+    lens?: {
+        enable?: boolean;
+        run?: boolean;
+        debug?: boolean;
+        implementations?: boolean;
+        refs?: boolean;
+        methodReferences?: boolean;
+        references?: boolean;
+        enumVariantReferences?: boolean;
+    };
+    hover?: {
+        documentation?: boolean;
+        keywords?: boolean;
+        linksInHover?: boolean;
+        memoryLayout?: {
+            enable?: boolean;
+        };
+    };
+    workspace?: {
+        symbol?: {
+            search?: {
+                scope?: "workspace" | "workspace_and_dependencies";
+                kind?: "only_types" | "all_symbols";
+            };
+        };
+    };
+}
+
+/**
+ * Initialization options for TypeScript/JavaScript language server
+ * @see https://github.com/typescript-language-server/typescript-language-server
+ */
+export interface TypeScriptInitializationOptions {
+    hostInfo?: string;
+    npmLocation?: string;
+    globalPlugins?: string[];
+    pluginProbeLocations?: string[];
+    preferences?: {
+        includePackageJsonAutoImports?: "auto" | "on" | "off";
+        providePrefixAndSuffixTextForRename?: boolean;
+        allowRenameOfImportPath?: boolean;
+        includeAutomaticOptionalChainCompletions?: boolean;
+        includeCompletionsForModuleExports?: boolean;
+        includeCompletionsForImportStatements?: boolean;
+        includeCompletionsWithSnippetText?: boolean;
+        includeCompletionsWithInsertText?: boolean;
+        allowIncompleteCompletions?: boolean;
+        importModuleSpecifier?: "shortest" | "relative" | "absolute" | "auto";
+        importModuleSpecifierEnding?: "minimal" | "index" | "js";
+        allowTextChangesInNewFiles?: boolean;
+        lazyConfiguredProjectsFromExternalProject?: boolean;
+        providePrefixAndSuffixTextForQuickInfo?: boolean;
+        includeInlayParameterNameHints?: "none" | "literals" | "all";
+        includeInlayParameterNameHintsWhenArgumentMatchesName?: boolean;
+        includeInlayFunctionParameterTypeHints?: boolean;
+        includeInlayVariableTypeHints?: boolean;
+        includeInlayVariableTypeHintsWhenTypeMatchesName?: boolean;
+        includeInlayPropertyDeclarationTypeHints?: boolean;
+        includeInlayFunctionLikeReturnTypeHints?: boolean;
+        includeInlayEnumMemberValueHints?: boolean;
+    };
+    locale?: string;
+    maxTsServerMemory?: number;
+    tsserver?: {
+        logLevel?: "off" | "terse" | "normal" | "requestTime" | "verbose";
+        logVerbosity?: "off" | "terse" | "normal" | "requestTime" | "verbose";
+        trace?: "off" | "messages" | "verbose";
+        useSeparateSyntaxServer?: boolean;
+        enableTracing?: boolean;
+        path?: string;
+    };
+}
+
+/**
+ * Initialization options for ESLint language server
+ * @see https://github.com/Microsoft/vscode-eslint
+ */
+export interface ESLintInitializationOptions {
+    packageManager?: "npm" | "yarn" | "pnpm";
+    nodePath?: string;
+    options?: Record<string, any>;
+    rules?: Record<string, any>;
+    rulesCustomizations?: Array<{
+        rule: string;
+        severity: "downgrade" | "upgrade" | "info" | "warn" | "error" | "off";
+    }>;
+    run?: "onType" | "onSave";
+    problems?: {
+        shortenToSingleLine?: boolean;
+    };
+    codeAction?: {
+        disableRuleComment?: {
+            enable?: boolean;
+            location?: "separateLine" | "sameLine";
+        };
+        showDocumentation?: {
+            enable?: boolean;
+        };
+    };
+    codeActionOnSave?: {
+        enable?: boolean;
+        mode?: "all" | "problems";
+    };
+    format?: {
+        enable?: boolean;
+    };
+    quiet?: boolean;
+    onIgnoredFiles?: "off" | "warn";
+    useESLintClass?: boolean;
+    experimental?: {
+        useFlatConfig?: boolean;
+    };
+    workingDirectory?: {
+        mode?: "auto" | "location";
+    };
+}
+
+/**
+ * Initialization options for Clangd language server
+ * @see https://clangd.llvm.org/config
+ */
+export interface ClangdInitializationOptions {
+    compilationDatabasePath?: string;
+    compilationDatabaseChanges?: Record<string, any>;
+    fallbackFlags?: string[];
+    clangdFileStatus?: boolean;
+    utf8?: boolean;
+    offsetEncoding?: ("utf-8" | "utf-16" | "utf-32")[];
+    index?: {
+        background?: "Build" | "Skip";
+        threads?: number;
+    };
+    completion?: {
+        detailedLabel?: boolean;
+        allScopes?: boolean;
+    };
+    hover?: {
+        showAKA?: boolean;
+    };
+    inlayHints?: {
+        enabled?: boolean;
+        parameterNames?: boolean;
+        deducedTypes?: boolean;
+        designators?: boolean;
+    };
+    semanticHighlighting?: boolean;
+    diagnostics?: {
+        unusedIncludes?: "None" | "Strict";
+        missingIncludes?: "None" | "Strict";
+        clangTidy?: boolean;
+        suppressAll?: boolean;
+    };
+}
+
+/**
+ * Initialization options for Gopls (Go language server)
+ * @see https://github.com/golang/tools/blob/master/gopls/doc/settings.md
+ */
+export interface GoplsInitializationOptions {
+    buildFlags?: string[];
+    env?: Record<string, string>;
+    directoryFilters?: string[];
+    templateExtensions?: string[];
+    memoryMode?: "DegradeClosed" | "Normal";
+    gofumpt?: boolean;
+    staticcheck?: boolean;
+    analyses?: Record<string, boolean>;
+    codelenses?: Record<string, boolean>;
+    usePlaceholders?: boolean;
+    completionBudget?: string;
+    diagnosticsDelay?: string;
+    experimentalPostfixCompletions?: boolean;
+    experimentalWorkspaceModule?: boolean;
+    experimentalTemplateSupport?: boolean;
+    semanticTokens?: boolean;
+    noSemanticString?: boolean;
+    noSemanticNumber?: boolean;
+    expandWorkspaceToModule?: boolean;
+    experimentalUseInvalidMetadata?: boolean;
+    hoverKind?: "FullDocumentation" | "NoDocumentation" | "SingleLine" | "Structured" | "SynopsisDocumentation";
+    linkTarget?: string;
+    linksInHover?: boolean;
+    importShortcut?: "Both" | "Definition" | "Link";
+    symbolMatcher?: "CaseInsensitive" | "CaseSensitive" | "FastFuzzy" | "Fuzzy";
+    symbolStyle?: "Dynamic" | "Full" | "Package";
+    verboseOutput?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,8 +120,8 @@ export class LanguageServerClient {
         this.initializePromise = this.initialize();
     }
 
-    public async initialize() {
-        const { capabilities } = await this.request("initialize", {
+    protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
+        return {
             capabilities: {
                 textDocument: {
                     hover: {
@@ -179,7 +179,15 @@ export class LanguageServerClient {
             processId: null,
             rootUri: this.rootUri,
             workspaceFolders: this.workspaceFolders,
-        }, timeout * 3);
+        }
+    }
+
+    public async initialize() {
+        const { capabilities } = await this.request(
+            "initialize",
+            this.getInitializationOptions(),
+            timeout * 3,
+        );
         this.capabilities = capabilities;
         this.notify("initialized", {});
         this.ready = true;
@@ -216,7 +224,7 @@ export class LanguageServerClient {
         if (this.autoClose) { this.close(); }
     }
 
-    private request<K extends keyof LSPRequestMap>(
+    protected request<K extends keyof LSPRequestMap>(
         method: K,
         params: LSPRequestMap[K][0],
         timeout: number,
@@ -224,7 +232,7 @@ export class LanguageServerClient {
         return this.client.request({ method, params }, timeout);
     }
 
-    private notify<K extends keyof LSPNotifyMap>(
+    protected notify<K extends keyof LSPNotifyMap>(
         method: K,
         params: LSPNotifyMap[K],
     ): Promise<LSPNotifyMap[K]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,7 @@ export class LanguageServerClient {
         return this.client.notify({ method, params });
     }
 
-    private processNotification(notification: Notification) {
+    protected processNotification(notification: Notification) {
         for (const plugin of this.plugins) {
             plugin.processNotification(notification);
         }


### PR DESCRIPTION
 Add support for setting `InitializationOptions` with arbitrary values and define interfaces for popular LSP servers:

 * `PyrightInitializationOptions` — Python (Pyright)
 * `RustAnalyzerInitializationOptions` — Rust (rust-analyzer)
 * `TypeScriptInitializationOptions` — TypeScript/JavaScript
 * `ESLintInitializationOptions` — ESLint
 * `ClangdInitializationOptions` — C/C++ (Clangd)
 * `GoplsInitializationOptions` — Go (`gopls`)

 Fixes #30
