### PR TITLE
Use explicit file suffixes in module imports

### DIFF
--- a/src/changes.ts
+++ b/src/changes.ts
@@ -1,6 +1,6 @@
 import type { Text, ChangeSet } from '@codemirror/state';
 import type * as LSP from 'vscode-languageserver-protocol';
-import { offsetToPos, posToOffset } from './pos';
+import { offsetToPos, posToOffset } from './pos.js';
 
 export function changeSetToEvents(
     doc: Text,

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,8 +1,8 @@
 import { Extension } from '@codemirror/state';
 import { autocompletion as cmAutocompletion } from '@codemirror/autocomplete';
 import { CompletionTriggerKind } from 'vscode-languageserver-protocol';
-import { languageServerPlugin } from './plugin';
-import { offsetToPos } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos } from './pos.js';
 
 export const autocompletion = (): Extension =>
     cmAutocompletion({

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,6 +1,6 @@
 import { EditorView, Command, KeyBinding } from '@codemirror/view';
-import { languageServerPlugin } from './plugin';
-import { offsetToPos } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos } from './pos.js';
 
 function requestDefinition(view: EditorView, pos: number): boolean {
     const plugin = view.plugin(languageServerPlugin);

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -2,8 +2,8 @@ import { Facet } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import type * as LSP from 'vscode-languageserver-protocol';
 
-import { languageServerPlugin } from './plugin';
-import { offsetToPos, posToOffset } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos, posToOffset } from './pos.js';
 
 /**
  * Facet for configuring LSP formatting options (tab size, spaces vs tabs, etc.).

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -8,8 +8,8 @@ import {
 } from '@codemirror/view';
 import { DocumentHighlightKind } from 'vscode-languageserver-protocol';
 
-import { languageServerPlugin } from './plugin';
-import { offsetToPos, posToOffset } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos, posToOffset } from './pos.js';
 
 const highlightField = StateField.define<DecorationSet>({
     create() {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,7 +1,7 @@
 import type { Tooltip } from '@codemirror/view';
 import { hoverTooltip as cmHoverTooltip } from '@codemirror/view';
-import { languageServerPlugin } from './plugin';
-import { offsetToPos } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos } from './pos.js';
 import { Extension } from '@codemirror/state';
 
 export const hoverTooltip = (): Extension =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,20 @@ export {
     LanguageServerClient,
     languageServerPlugin,
     SynchronizationMethod,
-} from './plugin';
-export { WebSocketTransport } from './jsonrpc';
-export type { Transport } from './jsonrpc';
+} from './plugin.js';
+export { WebSocketTransport } from './jsonrpc.js';
+export type { Transport } from './jsonrpc.js';
 export {
     jumpToDefinition,
     jumpToDefinitionPos,
     jumpToDefinitionKeymap,
-} from './definition';
+} from './definition.js';
 export {
     formatDocument,
     formatSelection,
     formattingOptions,
-} from './formatting';
-export { renameSymbol } from './rename';
+} from './formatting.js';
+export { renameSymbol } from './rename.js';
 export {
     PyrightInitializationOptions,
     RustAnalyzerInitializationOptions,
@@ -23,26 +23,26 @@ export {
     ESLintInitializationOptions,
     ClangdInitializationOptions,
     GoplsInitializationOptions,
-} from './initialization';
+} from './initialization.js';
 
 import { keymap } from '@codemirror/view';
-import { WebSocketTransport } from './jsonrpc';
+import { WebSocketTransport } from './jsonrpc.js';
 
 import {
     LanguageServerClient,
     languageServerPlugin,
     SynchronizationMethod,
-} from './plugin';
+} from './plugin.js';
 import type {
     LanguageServerClientOptions,
     LanguageServerBaseOptions,
-} from './plugin';
-import { jumpToDefinitionKeymap } from './definition';
-import { hoverTooltip } from './hover';
-import { autocompletion } from './completion';
-import { documentHighlight } from './highlight';
-import { mouseHandler } from './mouse';
-import { renameExtension } from './rename';
+} from './plugin.js';
+import { jumpToDefinitionKeymap } from './definition.js';
+import { hoverTooltip } from './hover.js';
+import { autocompletion } from './completion.js';
+import { documentHighlight } from './highlight.js';
+import { mouseHandler } from './mouse.js';
+import { renameExtension } from './rename.js';
 
 interface LanguageServerOptions<InitializationOptions = unknown>
     extends LanguageServerClientOptions<InitializationOptions> {

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,6 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
-import { jumpToDefinitionPos, jumpToTypeDefinitionPos } from './definition';
+import { jumpToDefinitionPos, jumpToTypeDefinitionPos } from './definition.js';
 
 export const mouseHandler = (): Extension =>
     EditorView.domEventHandlers({

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,8 +2,8 @@ import { insertCompletionText } from '@codemirror/autocomplete';
 import { setDiagnostics } from '@codemirror/lint';
 import { Facet } from '@codemirror/state';
 import { EditorView, Tooltip, ViewPlugin } from '@codemirror/view';
-import { JSONRPCClient, WebSocketTransport } from './jsonrpc';
-import type { Transport } from './jsonrpc';
+import { JSONRPCClient, WebSocketTransport } from './jsonrpc.js';
+import type { Transport } from './jsonrpc.js';
 import {
     CompletionItemKind,
     CompletionTriggerKind,
@@ -21,8 +21,8 @@ import { marked } from 'marked';
 import type { PublishDiagnosticsParams } from 'vscode-languageserver-protocol';
 import type * as LSP from 'vscode-languageserver-protocol';
 
-import { posToOffset, offsetToPos } from './pos';
-import { changeSetToEvents } from './changes';
+import { posToOffset, offsetToPos } from './pos.js';
+import { changeSetToEvents } from './changes.js';
 
 const timeout = 10000;
 

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -2,8 +2,8 @@ import { StateEffect, StateField } from '@codemirror/state';
 import { EditorView, showPanel, Panel } from '@codemirror/view';
 import type * as LSP from 'vscode-languageserver-protocol';
 
-import { languageServerPlugin } from './plugin';
-import { offsetToPos, posToOffset } from './pos';
+import { languageServerPlugin } from './plugin.js';
+import { offsetToPos, posToOffset } from './pos.js';
 
 const openRenamePanel = StateEffect.define<string>();
 const closeRenamePanel = StateEffect.define<null>();


### PR DESCRIPTION
When module resolution is set to `node16`, TypeScript throws a bunch of errors due to the missing file suffixes in imports. Adding them resolves the errors, allowing this package to be used with newer versions of Node.